### PR TITLE
Implode legacy signature

### DIFF
--- a/PDODb.php
+++ b/PDODb.php
@@ -432,7 +432,7 @@ class PDODb
         $isInsert    = in_array($this->queryType, ['REPLACE', 'INSERT']);
         $dataColumns = array_keys($tableData);
         if ($isInsert) {
-            if (isset($dataColumns[0])) $this->query .= ' (`'.implode($dataColumns, '`, `').'`) ';
+            if (isset($dataColumns[0])) $this->query .= ' (`'.implode('`, `', $dataColumns).'`) ';
             $this->query .= ' VALUES (';
         } else {
             $this->query .= " SET ";


### PR DESCRIPTION
Legacy signature (deprecated as of PHP 7.4.0, removed as of PHP 8.0.0).
https://www.php.net/manual/en/function.implode.php#:~:text=Legacy%20signature%20(deprecated%20as%20of%20PHP%207.4.0%2C%20removed%20as%20of%20PHP%208.0.0)%3A